### PR TITLE
Remove mock/dummy provisioner code

### DIFF
--- a/bin/load-templates.sh
+++ b/bin/load-templates.sh
@@ -9,11 +9,6 @@ MAINDIR=$(dirname $(cd $(dirname ${BASH_SOURCE[0]}) && pwd))
 
 dirs="clustertemplates hardwaretypes imagetypes providers services"
 
-if [ "x$COOPR_USE_DUMMY_PROVISIONER" == "xtrue" ]
-then
-  dirs="$dirs plugins/providertypes plugins/automatortypes"
-fi
-
 for d in ${dirs} ; do
   cd ${MAINDIR}
   [[ -d ${d} ]] && cd ${d} || continue


### PR DESCRIPTION
This is replaced by caskdata/coopr#692 and `load-mock.sh` so it should be merged afterwards and the submodule ref updated on Coopr.
