### PR TITLE
COOPR-568: changes to use TLS when talking to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ COOPR_SERVER_URI=${COOPR_SERVER_URI:-http://localhost:55054}
 COOPR_API_USER=${COOPR_API_USER:-admin}
 COOPR_API_KEY=${COOPR_API_KEY:-1234567890abcdef}
 COOPR_TENANT=${COOPR_TENANT:-superadmin}
-COOPR_CERT_PARAMETER=${COOPR_CERT_PARAMETER}
+TRUST_CERT_PATH=${TRUST_CERT_PATH}
+TRUST_CERT_PASSWORD=${TRUST_CERT_PASSWORD}
 ```
 
 You may modify these on the command line or by exporting them to your environment before running the script.
-COOPR_CERT_PARAMETER should be in format "--cert <trust certificate path>:<trust certificate password>".
 
 ### bin/jsonlint.sh
 

--- a/bin/load-templates.sh
+++ b/bin/load-templates.sh
@@ -6,7 +6,14 @@ COOPR_API_USER=${COOPR_API_USER:-admin}
 COOPR_API_KEY=${COOPR_API_KEY:-1234567890abcdef}
 COOPR_TENANT=${COOPR_TENANT:-superadmin}
 MAINDIR=$(dirname $(cd $(dirname ${BASH_SOURCE[0]}) && pwd))
-COOPR_CERT_PARAMETER=${COOPR_CERT_PARAMETER:-${CERT_PARAMETER}}
+
+if [ -z "$CERT_PARAMETER" ]; then
+  if [ -n "$TRUST_CERT_PATH" ] && [ -n "$TRUST_CERT_PASSWORD" ]; then
+    COOPR_CERT_PARAMETER="--cert ${TRUST_CERT_PATH}:${TRUST_CERT_PASSWORD}"
+  fi
+else
+  COOPR_CERT_PARAMETER="${CERT_PARAMETER}"
+fi
 
 dirs="clustertemplates hardwaretypes imagetypes providers services"
 


### PR DESCRIPTION
We should set up certificate creds when load templates on server in TLS mode.
Environment variable CERT_PARAMETER  is created in the coopr.sh script.
