### PR TITLE
latest joyent centos image

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -18,7 +18,7 @@
       "image": "centos-6-v20141108"
     },
     "joyent": {
-      "image": "26f85622-497a-11e4-ba93-3fe7b89aea1a"
+      "image": "f37b10cc-6a9f-11e4-9181-e3d137d947bf"
     },
     "rackspace": {
       "image": "3ab30cc6-c503-41d3-8a37-106fda7848a7"


### PR DESCRIPTION
updating to latest joyent centos6 image

```
$ knife joyent image list | grep centos-6 | sort -k 3 | tail -2
26f85622-497a-11e4-ba93-3fe7b89aea1a  centos-6                             20141001    linux    virtualmachine       
f37b10cc-6a9f-11e4-9181-e3d137d947bf  centos-6                             20141112    linux    virtualmachine     
```
