### PR TITLE
CoreOS Stable imagetype

### DIFF
--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,10 +15,10 @@
       "image": "6886342"
     },
     "google": {
-      "image": "coreos-stable-494-4-0-v20141204"
+      "image": "coreos-stable-494-5-0-v20141215"
     },
     "rackspace": {
-      "image": "749dc22a-9563-4628-b0d1-f84ced8c7b7a"
+      "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"
     }
   }
 }


### PR DESCRIPTION
This adds the CoreOS imagetype...

AWS: https://coreos.com/docs/running-coreos/cloud-providers/ec2/
DigitalOcean: https://coreos.com/docs/running-coreos/cloud-providers/digitalocean/
Google: https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/
Rackspace: https://coreos.com/docs/running-coreos/cloud-providers/rackspace/

**NOTE:** Joyent does not support CoreOS
