### PR TITLE
Update AWS hardware

### DIFF
--- a/hardwaretypes/standard-2xlarge.json
+++ b/hardwaretypes/standard-2xlarge.json
@@ -2,6 +2,27 @@
   "name": "standard-2xlarge",
   "description": "Standard server - 2XLarge 30GB",
   "providermap": {
+    "aws-us-east-1": {
+      "flavor": "m3.2xlarge",
+      "cost": "0.560",
+      "vcpu": "4",
+      "ram": "15",
+      "disks": "/dev/xvdb=80"
+    },
+    "aws-us-west-1": {
+      "flavor": "m3.2xlarge",
+      "cost": "0.560",
+      "vcpu": "4",
+      "ram": "15",
+      "disks": "/dev/xvdb=80"
+    },
+    "aws-us-west-2": {
+      "flavor": "m3.2xlarge",
+      "cost": "0.560",
+      "vcpu": "4",
+      "ram": "15",
+      "disks": "/dev/xvdb=80"
+    },
     "digitalocean": {
       "flavor": "60",
       "cost": "0.476",

--- a/hardwaretypes/standard-large.json
+++ b/hardwaretypes/standard-large.json
@@ -3,25 +3,22 @@
   "description": "Standard server - Large 8GB",
   "providermap": {
     "aws-us-east-1": {
-      "flavor": "m1.large",
-      "cost": "0.175",
+      "flavor": "m3.large",
+      "cost": "0.140",
       "vcpu": "2",
-      "ram": "7.5",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420"
+      "ram": "7.5"
     },
     "aws-us-west-1": {
-      "flavor": "m1.large",
-      "cost": "0.175",
+      "flavor": "m3.large",
+      "cost": "0.140",
       "vcpu": "2",
-      "ram": "7.5",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420"
+      "ram": "7.5"
     },
     "aws-us-west-2": {
-      "flavor": "m1.large",
-      "cost": "0.175",
+      "flavor": "m3.large",
+      "cost": "0.140",
       "vcpu": "2",
-      "ram": "7.5",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420"
+      "ram": "7.5"
     },
     "digitalocean": {
       "flavor": "65",

--- a/hardwaretypes/standard-medium.json
+++ b/hardwaretypes/standard-medium.json
@@ -3,25 +3,22 @@
   "description": "Standard server - Medium 4GB",
   "providermap": {
     "aws-us-east-1": {
-      "flavor": "m1.medium",
-      "cost": "0.087",
+      "flavor": "m3.medium",
+      "cost": "0.070",
       "vcpu": "1",
-      "ram": "3.75",
-      "disks": "/dev/xvdb=410"
+      "ram": "3.75"
     },
     "aws-us-west-1": {
-      "flavor": "m1.medium",
-      "cost": "0.087",
+      "flavor": "m3.medium",
+      "cost": "0.070",
       "vcpu": "1",
-      "ram": "3.75",
-      "disks": "/dev/xvdb=410"
+      "ram": "3.75"
     },
     "aws-us-west-2": {
-      "flavor": "m1.medium",
-      "cost": "0.087",
+      "flavor": "m3.medium",
+      "cost": "0.070",
       "vcpu": "1",
-      "ram": "3.75",
-      "disks": "/dev/xvdb=410"
+      "ram": "3.75"
     },
     "digitalocean": {
       "flavor": "64",

--- a/hardwaretypes/standard-xlarge.json
+++ b/hardwaretypes/standard-xlarge.json
@@ -3,25 +3,25 @@
   "description": "Standard server - XLarge 15GB",
   "providermap": {
     "aws-us-east-1": {
-      "flavor": "m1.xlarge",
-      "cost": "0.350",
+      "flavor": "m3.xlarge",
+      "cost": "0.280",
       "vcpu": "4",
       "ram": "15",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420,/dev/xvdd=420,/dev/xvde=420"
+      "disks": "/dev/xvdb=40"
     },
     "aws-us-west-1": {
-      "flavor": "m1.xlarge",
-      "cost": "0.350",
+      "flavor": "m3.xlarge",
+      "cost": "0.280",
       "vcpu": "4",
       "ram": "15",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420,/dev/xvdd=420,/dev/xvde=420"
+      "disks": "/dev/xvdb=40"
     },
     "aws-us-west-2": {
-      "flavor": "m1.xlarge",
-      "cost": "0.350",
+      "flavor": "m3.xlarge",
+      "cost": "0.280",
       "vcpu": "4",
       "ram": "15",
-      "disks": "/dev/xvdb=420,/dev/xvdc=420,/dev/xvdd=420,/dev/xvde=420"
+      "disks": "/dev/xvdb=40"
     },
     "digitalocean": {
       "flavor": "61",


### PR DESCRIPTION
The m1 hardware types are deprecated. We should use the m3 hardware.
