### PR TITLE
configure hive to use IPs instead of hostname due to issues seen with ho...

### DIFF
--- a/clustertemplates/cdap-distributed.json
+++ b/clustertemplates/cdap-distributed.json
@@ -85,11 +85,11 @@
           "hive_log_dir": "/data/logs/hive"
         },
         "hive_site": {
-          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%host.service.mysql-server%:3306/hive?createDatabaseIfNotExist=true",
+          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%ip.bind_v4.service.mysql-server%:3306/hive?createDatabaseIfNotExist=true",
           "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
           "javax.jdo.option.ConnectionUserName": "dbuser",
           "javax.jdo.option.ConnectionPassword": "dbuserpassword",
-          "hive.metastore.uris": "%join(map(host.service.hive-metastore,'thrift://$:9083'),',')%",
+          "hive.metastore.uris": "%join(map(ip.bind_v4.service.hive-metastore,'thrift://$:9083'),',')%",
           "hive.zookeeper.quorum": "%join(map(host.service.zookeeper-server,'$'),',')%",
           "hive.support.concurrency": "true"
         }

--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -97,7 +97,7 @@
           "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
           "javax.jdo.option.ConnectionUserName": "dbuser",
           "javax.jdo.option.ConnectionPassword": "dbuserpassword",
-          "hive.metastore.uris": "%join(map(host.service.hive-metastore,'thrift://$:9083'),',')%",
+          "hive.metastore.uris": "%join(map(ip.bind_v4.service.hive-metastore,'thrift://$:9083'),',')%",
           "hive.zookeeper.quorum": "%join(map(host.service.zookeeper-server,'$'),',')%",
           "hive.support.concurrency": "true",
           "hive.server2.thrift.port": "10010"

--- a/clustertemplates/hadoop-distributed.json
+++ b/clustertemplates/hadoop-distributed.json
@@ -66,11 +66,11 @@
           "hive_log_dir": "/data/logs/hive"
         },
         "hive_site": {
-          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%host.service.mysql-server%:3306/hive",
+          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%ip.bind_v4.service.mysql-server%:3306/hive",
           "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
           "javax.jdo.option.ConnectionUserName": "dbuser",
           "javax.jdo.option.ConnectionPassword": "dbuserpassword",
-          "hive.metastore.uris": "%join(map(host.service.hive-metastore,'thrift://$:9083'),',')%",
+          "hive.metastore.uris": "%join(map(ip.bind_v4.service.hive-metastore,'thrift://$:9083'),',')%",
           "hive.support.concurrency": "true",
           "hive.zookeeper.quorum": "%join(map(host.service.zookeeper-server,'$'),',')%"
         }

--- a/clustertemplates/hadoop-singlenode.json
+++ b/clustertemplates/hadoop-singlenode.json
@@ -87,7 +87,7 @@
           "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
           "javax.jdo.option.ConnectionUserName": "dbuser",
           "javax.jdo.option.ConnectionPassword": "dbuserpassword",
-          "hive.metastore.uris": "%join(map(host.service.hive-metastore,'thrift://$:9083'),',')%",
+          "hive.metastore.uris": "%join(map(ip.bind_v4.service.hive-metastore,'thrift://$:9083'),',')%",
           "hive.zookeeper.quorum": "%join(map(host.service.zookeeper-server,'$'),',')%",
           "hive.support.concurrency": "true",
           "hive.server2.thrift.port": "10010"


### PR DESCRIPTION
...stnames

Workaround for https://issues.cask.co/browse/COOPR-713.
- [x] Configures hive metastore to use bind IP instead of hostname
