### PR TITLE
Initialization step for MR JHS

### DIFF
--- a/services/hadoop-mapreduce-historyserver.json
+++ b/services/hadoop-mapreduce-historyserver.json
@@ -30,6 +30,12 @@
           "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
         }
       },
+      "initialize": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::hadoop_mapreduce_historyserver_init]"
+        }
+      },
       "start": {
         "type": "chef-solo",
         "fields": {


### PR DESCRIPTION
Without this, many things writing out job history files will fail. On secure clusters, this can cause failures in Hive jobs being processed.
