### PR TITLE
COOPR-748 Maven service

### DIFF
--- a/services/maven.json
+++ b/services/maven.json
@@ -1,0 +1,32 @@
+{
+  "name": "maven",
+  "description": "Apache Maven Java build system",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": []
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": []
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[maven::default]"
+        }
+      },
+      "configure": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[maven::default]"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This allows us to add a `maven` service to any clustertemplate in Coopr.
