### PR TITLE
Support more Linux distributions

### DIFF
--- a/imagetypes/centos5.json
+++ b/imagetypes/centos5.json
@@ -1,0 +1,15 @@
+{
+  "name": "centos5",
+  "description": "CentOS 5 64-bit",
+  "providermap": {
+    "digitalocean": {
+      "image": "6372321"
+    },
+    "joyent": {
+      "image": "2539f6de-0b5a-11e2-b647-fb08c3503fb2"
+    },
+    "rackspace": {
+      "image": "d2fa624e-a6ec-4752-a738-81fc4b2462af"
+    }
+  }
+}

--- a/imagetypes/centos7.json
+++ b/imagetypes/centos7.json
@@ -1,0 +1,15 @@
+{
+  "name": "centos7",
+  "description": "CentOS 7 64-bit",
+  "providermap": {
+    "digitalocean": {
+      "image": "10322623"
+    },
+    "google": {
+      "image": "centos-7-v20150226"
+    },
+    "joyent": {
+      "image": "02dbab66-a70a-11e4-819b-b3dc41b361d6"
+    }
+  }
+}

--- a/imagetypes/debian6.json
+++ b/imagetypes/debian6.json
@@ -1,0 +1,27 @@
+{
+  "name": "debian6",
+  "description": "Debian 6 (Squeeze) 64-bit",
+  "providermap": {
+    "aws-us-east-1": {
+      "image": "ami-5e12dc36",
+      "sshuser": "admin"
+    },
+    "aws-us-west-1": {
+      "image": "ami-6b3d3e2e",
+      "sshuser": "admin"
+    },
+    "aws-us-west-2": {
+      "image": "ami-01146c31",
+      "sshuser": "admin"
+    },
+    "digitalocean": {
+      "image": "6372581"
+    },
+    "joyent": {
+      "image": "94384a12-bbeb-11e2-aec2-2bfa9742484b"
+    },
+    "rackspace": {
+      "image": "cad1e45d-fcb9-489d-850c-a61c0537fa55"
+    }
+  }
+}

--- a/imagetypes/debian7.json
+++ b/imagetypes/debian7.json
@@ -1,0 +1,27 @@
+{
+  "name": "debian7",
+  "description": "Debian 7 (Wheezy) 64-bit",
+  "providermap": {
+    "aws-us-east-1": {
+      "image": "ami-74efab1c",
+      "sshuser": "admin"
+    },
+    "aws-us-west-1": {
+      "image": "ami-70b9a035",
+      "sshuser": "admin"
+    },
+    "aws-us-west-2": {
+      "image": "ami-a31a4293",
+      "sshuser": "admin"
+    },
+    "digitalocean": {
+      "image": "10322059"
+    },
+    "google": {
+      "image": "debian-7-wheezy-v20150226"
+    },
+    "joyent": {
+      "image": "5f41692e-a70d-11e4-8c2d-afc6735144dc"
+    }
+  }
+}

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -22,7 +22,7 @@
       "sshuser": "ubuntu"
     },
     "joyent": {
-      "image": "c864f104-624c-43d2-835e-b49a39709b6b"
+      "image": "c864f104-624c-43d2-835e-b49a39709b6b",
       "sshuser": "ubuntu"
     },
     "rackspace": {

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -1,0 +1,32 @@
+{
+  "name": "ubuntu14",
+  "description": "Ubuntu 14.04 LTS (Trusty Tahr) 64-bit",
+  "providermap": {
+    "aws-us-east-1": {
+      "image": "ami-3e8ad556",
+      "sshuser": "ubuntu"
+    },
+    "aws-us-west-1": {
+      "image": "ami-17876353",
+      "sshuser": "ubuntu"
+    },
+    "aws-us-west-2": {
+      "image": "ami-ef3414df",
+      "sshuser": "ubuntu"
+    },
+    "digitalocean": {
+      "image": "9801950"
+    },
+    "google": {
+      "image": "ubuntu-1404-trusty-v20150128",
+      "sshuser": "ubuntu"
+    },
+    "joyent": {
+      "image": "c864f104-624c-43d2-835e-b49a39709b6b"
+      "sshuser": "ubuntu"
+    },
+    "rackspace": {
+      "image": "28d39e78-a41c-4fd2-80b4-dc960c055074"
+    }
+  }
+}


### PR DESCRIPTION
Adds CentOS 5 and 7, Debian 6 and 7, and Ubuntu 14. These images are only the paravirtualized (PV) images, which can run on any hardwaretype. Some providers have HVM/PVHVM images of some of these distributions, but they require specific instance types on the remote end, and Coopr currently has no way of filtering these. As such, I am leaving them out, so the solver can fail clusters with an invalid combination at submission, versus failing at create time.
