### PR TITLE
Update images for CentOS 6 and Ubuntu 12

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -15,13 +15,13 @@
       "image": "10325922"
     },
     "google": {
-      "image": "centos-6-v20150127"
+      "image": "centos-6-v20150226"
     },
     "joyent": {
-      "image": "f37b10cc-6a9f-11e4-9181-e3d137d947bf"
+      "image": "5becfd74-a70d-11e4-93a6-470507be237c"
     },
     "rackspace": {
-      "image": "3ab30cc6-c503-41d3-8a37-106fda7848a7"
+      "image": "2318853e-f3b1-4cf4-b1a4-d7db71ca9b50"
     }
   }
 }

--- a/imagetypes/ubuntu12.json
+++ b/imagetypes/ubuntu12.json
@@ -3,15 +3,15 @@
   "description": "Ubuntu 12.04 LTS (Precise Pangolin) 64-bit",
   "providermap": {
     "aws-us-east-1": {
-      "image": "ami-ecda6c84",
+      "image": "ami-d6cf93be",
       "sshuser": "ubuntu"
     },
     "aws-us-west-1": {
-      "image": "ami-115c5754",
+      "image": "ami-b1a044f5",
       "sshuser": "ubuntu"
     },
     "aws-us-west-2": {
-      "image": "ami-ad42009d",
+      "image": "ami-75755545",
       "sshuser": "ubuntu"
     },
     "digitalocean": {
@@ -22,11 +22,11 @@
       "sshuser": "ubuntu"
     },
     "joyent": {
-      "image": "01a24b88-f957-4f9d-9946-fbd21b0612bf",
+      "image": "415e39e6-26f1-48c4-85b1-9697066fc1a9",
       "sshuser": "ubuntu"
     },
     "rackspace": {
-      "image": "2f85a777-9ffd-4b49-a60e-1155ceb93a5e"
+      "image": "71893ec7-b625-44a5-b333-ca19885b941d"
     }
   }
 }


### PR DESCRIPTION
These were the latest images, as of March 4th.
