### PR TITLE
Create service and template for caskdata/coopr-standalone container image on Docker Hub

### DIFF
--- a/clustertemplates/coopr-standalone-docker.json
+++ b/clustertemplates/coopr-standalone-docker.json
@@ -1,0 +1,52 @@
+{
+  "name": "coopr-standalone-docker",
+  "description": "Coopr Standalone in a Docker container",
+  "defaults": {
+    "services": [
+      "coopr-standalone"
+    ],
+    "provider": "rackspace",
+    "hardwaretype": "standard-medium",
+    "imagetype": "coreos-stable",
+    "config": {}
+  },
+  "compatibility": {
+    "hardwaretypes": [
+      "standard-2xlarge",
+      "standard-large",
+      "standard-medium",
+      "standard-small",
+      "standard-xlarge"
+    ],
+    "imagetypes": [
+      "coreos-stable"
+    ],
+    "services": [
+      "coopr-standalone"
+    ]
+  },
+  "constraints": {
+    "layout": {
+      "mustcoexist": [],
+      "cantcoexist": []
+    },
+    "services": {},
+    "size": {
+      "min": 1,
+      "max": 1
+    }
+  },
+  "administration": {
+    "leaseduration": {
+      "initial": 0,
+      "max": 0,
+      "step": 0
+    }
+  },
+  "links": [
+    {
+      "label": "Coopr UI",
+      "url": "http://%ip.access_v4.service.coopr%:8100"
+    }
+  ]
+}

--- a/services/coopr-standalone.json
+++ b/services/coopr-standalone.json
@@ -1,0 +1,47 @@
+{
+  "name": "coopr-standalone",
+  "description": "Coopr Standalone running in a Docker container (caskdata/coopr-standalone)",
+  "dependencies": {
+    "provides": [],
+    "conflicts": [
+      "coopr"
+    ],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "caskdata/coopr-standalone",
+          "publish_ports": "8100,55054"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "caskdata/coopr-standalone",
+          "publish_ports": "8100,55054"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "caskdata/coopr-standalone",
+          "publish_ports": "8100,55054"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is similar to the `cdap-standalone-docker` clustertemplate and the `cdap-standalone` service.
