### PR TITLE
Support Spark HistoryServer for Spark on YARN

### DIFF
--- a/clustertemplates/cdap-distributed.json
+++ b/clustertemplates/cdap-distributed.json
@@ -155,7 +155,8 @@
       "mysql-server",
       "hive-metastore-database",
       "hive-metastore",
-      "hive-server2"
+      "hive-server2",
+      "spark-historyserver"
     ]
   },
   "constraints": {
@@ -174,6 +175,7 @@
           "hadoop-hdfs-namenode",
           "hadoop-yarn-resourcemanager",
           "hadoop-mapreduce-historyserver",
+          "spark-historyserver",
           "hbase-master",
           "mysql-server",
           "zookeeper-server",

--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -161,8 +161,7 @@
     ],
     "imagetypes": [
       "centos6",
-      "ubuntu12",
-      "Fedora19"
+      "ubuntu12"
     ],
     "services": [
       "base",
@@ -179,7 +178,8 @@
       "mysql-server",
       "hive-metastore-database",
       "hive-metastore",
-      "hive-server2"
+      "hive-server2",
+      "spark-historyserver"
     ]
   },
   "constraints": {

--- a/clustertemplates/hadoop-distributed.json
+++ b/clustertemplates/hadoop-distributed.json
@@ -119,7 +119,8 @@
       "mysql-server",
       "hive-metastore-database",
       "hive-metastore",
-      "hive-server2"
+      "hive-server2",
+      "spark-historyserver"
     ]
   },
   "constraints": {
@@ -142,7 +143,8 @@
           "hive-metastore-database",
           "hive-metastore",
           "zookeeper-server",
-          "hive-server2"
+          "hive-server2",
+          "spark-historyserver"
         ]
       ],
       "cantcoexist": [

--- a/clustertemplates/hadoop-singlenode.json
+++ b/clustertemplates/hadoop-singlenode.json
@@ -142,7 +142,8 @@
       "mysql-server",
       "hive-metastore-database",
       "hive-metastore",
-      "hive-server2"
+      "hive-server2",
+      "spark-historyserver"
     ]
   },
   "constraints": {

--- a/services/spark-historyserver.json
+++ b/services/spark-historyserver.json
@@ -1,0 +1,52 @@
+{
+  "name": "spark-historyserver",
+  "description": "Spark History Server",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "kerberos-master" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop::spark_historyserver]"
+        }
+      },
+      "configure": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark]"
+        }
+      },
+      "initialize": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::spark_historyserver_init]"
+        }
+      },
+      "start": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark_historyserver],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"spark-history-server\": \"start\" } } } }" 
+        }
+      },
+      "stop": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark_historyserver],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"spark-history-server\": \"stop\" } } } }" 
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will start up the Spark HistoryServer on the same node as the NameNode. Some configuration may still be needed. This will bring in all of the Spark libraries and binaries and make them available on the master node. I have also added it to the compatibility on `cdap-*` and `hadoop-*` clustertemplates.
