### PR TITLE
Support cdap-security service

### DIFF
--- a/clustertemplates/cdap-distributed.json
+++ b/clustertemplates/cdap-distributed.json
@@ -152,6 +152,7 @@
       "hbase-master",
       "hbase-regionserver",
       "cdap",
+      "cdap-security",
       "mysql-server",
       "hive-metastore-database",
       "hive-metastore",
@@ -178,6 +179,7 @@
           "mysql-server",
           "zookeeper-server",
           "cdap",
+          "cdap-security",
           "mysql-server",
           "hive-metastore",
           "hive-metastore-database"
@@ -234,6 +236,12 @@
         }
       },
       "cdap": {
+        "quantities": {
+          "min": 1,
+          "max": 1
+        }
+      },
+      "cdap-security": {
         "quantities": {
           "min": 1,
           "max": 1


### PR DESCRIPTION
This adds the service to compatibility. It will still need to be configured, as desired, by anyone who uses the service on their cluster.
