### PR TITLE
Spark on YARN requires HDFS and YARN

### DIFF
--- a/services/spark-historyserver.json
+++ b/services/spark-historyserver.json
@@ -10,7 +10,11 @@
     "provides": [],
     "runtime": {
       "requires": [],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "kerberos-master",
+        "hadoop-hdfs-namenode",
+        "hadoop-yarn-resourcemanager"
+      ]
     }
   },
   "provisioner": {


### PR DESCRIPTION
Running Spark on YARN requires the HDFS directory for the HistoryServer.

```
[2015-06-24T20:08:14+00:00] ERROR: ruby_block[initaction-create-hdfs-spark-userdir] (hadoop_wrapper::spark_historyserver_init line 24) had an error: Mixlib::ShellOut::ShellCommandFailed: execute[hdfs-spark-userdir] (hadoop::spark_historyserver line 25) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of hdfs dfs -mkdir -p hdfs://localhost/user/spark && hdfs dfs -chown -R spark:spark hdfs://localhost/user/spark ----
STDOUT:
STDERR: mkdir: Call From localhost/127.0.0.1 to localhost:8020 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/ConnectionRefused
---- End output of hdfs dfs -mkdir -p hdfs://localhost/user/spark && hdfs dfs -chown -R spark:spark hdfs://localhost/user/spark ----
```

Putting `hadoop-hdfs-namenode` and `hadoop-yarn-resourcemanager` in runtime uses will force the `spark-historyserver` initialize to run after HDFS is started.
