### PR TITLE
remove zookeeper-server init as it is handled in the hadoop cookbook …

### DIFF
--- a/services/zookeeper-server.json
+++ b/services/zookeeper-server.json
@@ -27,12 +27,6 @@
           "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::zookeeper_server]"
         }
       },
-      "initialize": {
-        "type": "chef-solo",
-        "fields": {
-          "run_list": "recipe[hadoop_wrapper::zookeeper_server_init]"
-        }
-      },
       "start": {
         "type": "chef-solo",
         "fields": {


### PR DESCRIPTION
…instead

Zookeeper's init recipe was removed from hadoop_wrapper, originally in https://github.com/caskdata/hadoop_wrapper_cookbook/pull/42

Now that it has been properly imported to Coopr in https://github.com/caskdata/coopr-provisioner/pull/91, this service must be updated.
