### PR TITLE
Increase AM resource percentage to 40% of cluster

### DIFF
--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -70,6 +70,7 @@
           "yarn.resourcemanager.resource-tracker.address": "%host.service.hadoop-yarn-resourcemanager%:8031",
           "yarn.resourcemanager.address": "%host.service.hadoop-yarn-resourcemanager%:8032",
           "yarn.resourcemanager.admin.address": "%host.service.hadoop-yarn-resourcemanager%:8033",
+          "yarn.scheduler.capacity.maximum-am-resource-percent": "0.4",
           "yarn.scheduler.minimum-allocation-mb": "256"
         }
       },


### PR DESCRIPTION
Raising this is necessary for a small cluster such as singlenode, where there may be a large number of AM containers compared to total cluster size.
