### PR TITLE
Feature/remove cdap dependency on wrapper

### DIFF
--- a/services/cdap-security.json
+++ b/services/cdap-security.json
@@ -42,14 +42,14 @@
       "start": {
         "fields": {
           "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-auth-server\": \"start\" } } } }",
-          "run_list": "recipe[hadoop_wrapper::default],recipe[cdap::security],recipe[coopr_service_manager::default]"
+          "run_list": "recipe[cdap::security],recipe[coopr_service_manager::default]"
         },
         "type": "chef-solo"
       },
       "stop": {
         "fields": {
           "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-auth-server\": \"stop\" } } } }",
-          "run_list": "recipe[hadoop_wrapper::default],recipe[cdap::security],recipe[coopr_service_manager::default]"
+          "run_list": "recipe[cdap::security],recipe[coopr_service_manager::default]"
         },
         "type": "chef-solo"
       }

--- a/services/cdap.json
+++ b/services/cdap.json
@@ -35,7 +35,8 @@
       "install": {
         "type":"chef-solo",
         "fields": {
-          "run_list": "recipe[cdap::fullstack]"
+          "run_list": "recipe[cdap::fullstack]",
+          "json_attributes": "{\"cdap\": {\"skip_prerequisites\": \"true\" } }"
         }
       },
       "configure": {
@@ -54,14 +55,14 @@
         "type": "chef-solo",
         "fields": {
           "run_list": "recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"start\", \"cdap-router\": \"start\", \"cdap-kafka-server\": \"start\", \"cdap-ui\": \"start\" } } }, "cdap": {"skip_prerequisites": "true" } }"
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"start\", \"cdap-router\": \"start\", \"cdap-kafka-server\": \"start\", \"cdap-ui\": \"start\" } } }, {\"cdap\": {\"skip_prerequisites\": \"true\" } } }"
         }
       },
       "stop": {
         "type": "chef-solo",
         "fields": {
           "run_list": "recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"stop\", \"cdap-router\": \"stop\", \"cdap-kafka-server\": \"stop\", \"cdap-ui\": \"stop\" } } }, "cdap": {"skip_prerequisites": "true" } }"
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"stop\", \"cdap-router\": \"stop\", \"cdap-kafka-server\": \"stop\", \"cdap-ui\": \"stop\" } } }, {\"cdap\": {\"skip_prerequisites\": \"true\" } } }"
         }
       }
     }

--- a/services/cdap.json
+++ b/services/cdap.json
@@ -47,21 +47,21 @@
       "initialize": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[cdap::init]"
+          "run_list": "recipe[cdap::init]"
         }
       },
       "start": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"start\", \"cdap-router\": \"start\", \"cdap-kafka-server\": \"start\", \"cdap-ui\": \"start\" } } } }"
+          "run_list": "recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"start\", \"cdap-router\": \"start\", \"cdap-kafka-server\": \"start\", \"cdap-ui\": \"start\" } } }, "cdap": {"skip_prerequisites": "true" } }"
         }
       },
       "stop": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"stop\", \"cdap-router\": \"stop\", \"cdap-kafka-server\": \"stop\", \"cdap-ui\": \"stop\" } } } }"
+          "run_list": "recipe[cdap::fullstack],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"cdap-master\": \"stop\", \"cdap-router\": \"stop\", \"cdap-kafka-server\": \"stop\", \"cdap-ui\": \"stop\" } } }, "cdap": {"skip_prerequisites": "true" } }"
         }
       }
     }


### PR DESCRIPTION
removing `hadoop_wrapper` from the `cdap` and `cdap-security` services' run_list.  This should make it possible to use the same cdap service with alternate cookbooks such as hadoop_mapr
- [x] `cdap-security` just doesn't need it
- [x] `cdap` used it to ensure hadoop/hbase clients were installed, which in the context of Coopr is always satisfied by service dependencies.  Therefore, we can remove this by setting the `{\"cdap\": {\"skip_prerequisites\": \"true\" } }` attribute in the service json wherever the `cdap::default` recipe gets invoked (via `fullstack`).
