### PR TITLE
Feature/mapr ha interference

### DIFF
--- a/services/cdap.json
+++ b/services/cdap.json
@@ -10,7 +10,11 @@
         "hbase-master",
         "zookeeper-server"
       ],
-      "uses": []
+      "uses": [
+        "hadoop-client",
+        "hbase-client",
+        "hive-client"
+      ]
     },
     "provides": [],
     "runtime": {

--- a/services/hadoop-client.json
+++ b/services/hadoop-client.json
@@ -1,0 +1,32 @@
+{
+  "name": "hadoop-client",
+  "description": "Configures Hadoop/Yarn libraries and client",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "kerberos-master" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default]"
+        }
+      },
+      "configure": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default]"
+        }
+      }
+    }
+  }
+}

--- a/services/hadoop-hdfs-datanode.json
+++ b/services/hadoop-hdfs-datanode.json
@@ -7,7 +7,9 @@
       "requires": [ "base" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hadoop-client"
+    ],
     "runtime": {
       "requires": [ "hadoop-hdfs-namenode" ],
       "uses": [

--- a/services/hadoop-hdfs-namenode.json
+++ b/services/hadoop-hdfs-namenode.json
@@ -7,7 +7,9 @@
       "requires": [ "base" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hadoop-client"
+    ],
     "runtime": {
       "requires": [],
       "uses": [ "kerberos-master" ]

--- a/services/hadoop-yarn-nodemanager.json
+++ b/services/hadoop-yarn-nodemanager.json
@@ -7,7 +7,9 @@
       "requires": [ "base" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hadoop-client"
+    ],
     "runtime": {
       "requires": [ "hadoop-yarn-resourcemanager" ],
       "uses": [ "kerberos-master" ]

--- a/services/hadoop-yarn-resourcemanager.json
+++ b/services/hadoop-yarn-resourcemanager.json
@@ -7,7 +7,9 @@
       "requires": [ "base" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hadoop-client"
+    ],
     "runtime": {
       "requires": [ "hadoop-hdfs-namenode", "hadoop-hdfs-datanode" ],
       "uses": [ "kerberos-master" ]

--- a/services/hbase-client.json
+++ b/services/hbase-client.json
@@ -1,0 +1,32 @@
+{
+  "name": "hbase-client",
+  "description": "Configures HBase libraries and client",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "kerberos-master" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase]"
+        }
+      },
+      "configure": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase]"
+        }
+      }
+    }
+  }
+}

--- a/services/hbase-master.json
+++ b/services/hbase-master.json
@@ -7,7 +7,9 @@
       "requires": [ "base", "zookeeper-server" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hbase-client"
+    ],
     "runtime": {
       "requires": [
         "hadoop-hdfs-namenode",

--- a/services/hbase-regionserver.json
+++ b/services/hbase-regionserver.json
@@ -7,7 +7,9 @@
       "requires": [ "base", "zookeeper-server" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "hbase-client"
+    ],
     "runtime": {
       "requires": [
         "hbase-master",

--- a/services/hive-client.json
+++ b/services/hive-client.json
@@ -1,0 +1,32 @@
+{
+  "name": "hive-client",
+  "description": "Configures Hive libraries and client",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "kerberos-master" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive]"
+        }
+      },
+      "configure": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive]"
+        }
+      }
+    }
+  }
+}

--- a/services/hive-metastore.json
+++ b/services/hive-metastore.json
@@ -9,7 +9,9 @@
       ],
       "uses": []
     },
-    "provides": [],
+    "provides": [
+      "hive-client"
+    ],
     "runtime": {
       "requires": [
         "hadoop-hdfs-namenode",


### PR DESCRIPTION
This adds new client services: `hadoop-client`, `hbase-client`, and `hive-client` which can be used to make more flexible clustertemplates.

This solves a problem introduced by https://github.com/caskdata/coopr-templates/pull/55, which incorrectly assumed these client dependencies were always provided by coopr.  It is possible to create templates which produce nodes with only `base` and `cdap`.  These client services will be easy to add to such templates to provide the clients needed by CDAP.
