### PR TITLE
DockerAutomator-based service templates

### DIFF
--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -1,0 +1,57 @@
+{
+  "name": "docker-all",
+  "description": "Docker services on Linux",
+  "defaults": {
+    "services": [
+      "base",
+      "docker"
+    ],
+    "provider": "rackspace",
+    "hardwaretype": "standard-medium",
+    "imagetype": "ubuntu12",
+    "config": {}
+  },
+  "compatibility": {
+    "hardwaretypes": [
+      "standard-2xlarge",
+      "standard-large",
+      "standard-medium",
+      "standard-small",
+      "standard-xlarge"
+    ],
+    "imagetypes": [
+      "centos6",
+      "centos7",
+      "ubuntu12",
+      "ubuntu14"
+    ],
+    "services": [
+      "base",
+      "cassandra-docker",
+      "cdap-standalone",
+      "coopr-standalone"
+      "docker",
+      "elasticsearch-docker",
+      "mongodb-docker"
+    ]
+  },
+  "constraints": {
+    "layout": {
+      "mustcoexist": [],
+      "cantcoexist": []
+    },
+    "services": {},
+    "size": {
+      "min": 1,
+      "max": 1
+    }
+  },
+  "administration": {
+    "leaseduration": {
+      "initial": 0,
+      "max": 0,
+      "step": 0
+    }
+  },
+  "links": []
+}

--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -29,7 +29,7 @@
       "base",
       "cassandra-docker",
       "cdap-standalone",
-      "coopr-standalone"
+      "coopr-standalone",
       "docker",
       "elasticsearch-docker",
       "mongodb-docker"

--- a/services/cassandra-docker.json
+++ b/services/cassandra-docker.json
@@ -1,0 +1,45 @@
+{
+  "name": "cassandra-docker",
+  "description": "Apache Cassandra running in a Docker container (cassandra)",
+  "dependencies": {
+    "provides": [ "cassandra" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "cassandra",
+          "publish_ports": "7000"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "cassandra",
+          "publish_ports": "7000"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "cassandra",
+          "publish_ports": "7000"
+        }
+      }
+    }
+  }
+}

--- a/services/elasticsearch-docker.json
+++ b/services/elasticsearch-docker.json
@@ -1,0 +1,45 @@
+{
+  "name": "elasticsearch-docker",
+  "description": "Apache Cassandra running in a Docker container (elasticsearch)",
+  "dependencies": {
+    "provides": [ "elasticsearch" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "elasticsearch",
+          "publish_ports": "9200,9300"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "elasticsearch",
+          "publish_ports": "9200,9300"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "elasticsearch",
+          "publish_ports": "9200,9300"
+        }
+      }
+    }
+  }
+}

--- a/services/elasticsearch-docker.json
+++ b/services/elasticsearch-docker.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-docker",
-  "description": "Apache Cassandra running in a Docker container (elasticsearch)",
+  "description": "Elasticsearch running in a Docker container (elasticsearch)",
   "dependencies": {
     "provides": [ "elasticsearch" ],
     "conflicts": [],

--- a/services/mongodb-docker.json
+++ b/services/mongodb-docker.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-docker",
-  "description": "Apache Cassandra running in a Docker container (mongo)",
+  "description": "MongoDB running in a Docker container (mongo)",
   "dependencies": {
     "provides": [ "mongodb" ],
     "conflicts": [],

--- a/services/mongodb-docker.json
+++ b/services/mongodb-docker.json
@@ -1,0 +1,45 @@
+{
+  "name": "mongodb-docker",
+  "description": "Apache Cassandra running in a Docker container (mongo)",
+  "dependencies": {
+    "provides": [ "mongodb" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mongo",
+          "publish_ports": "27017"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mongo",
+          "publish_ports": "27017"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mongo",
+          "publish_ports": "27017"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These services use the DockerAutomator and use official images as
published to Docker Hub and automatically publish the default
exposed ports.
- [x] [cassandra](https://hub.docker.com/_/cassandra/)
- [x] [elasticsearch](https://hub.docker.com/_/elasticsearch/)
- [x] [mongodb](https://hub.docker.com/_/mongo/)

For any additional configuration, logins, etc. check the image's
page on Docker Hub.
