### PR TITLE
Update configure action to use correct recipe

### DIFF
--- a/services/hadoop-hdfs-datanode.json
+++ b/services/hadoop-hdfs-datanode.json
@@ -29,7 +29,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_hdfs_datanode]"
         }
       },
       "start": {

--- a/services/hadoop-hdfs-namenode.json
+++ b/services/hadoop-hdfs-namenode.json
@@ -26,7 +26,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_hdfs_namenode]"
         }
       },
       "initialize": {

--- a/services/hadoop-mapreduce-historyserver.json
+++ b/services/hadoop-mapreduce-historyserver.json
@@ -30,7 +30,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_mapreduce_historyserver]"
         }
       },
       "initialize": {

--- a/services/hadoop-yarn-nodemanager.json
+++ b/services/hadoop-yarn-nodemanager.json
@@ -26,7 +26,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_yarn_nodemanager]"
         }
       },
       "start": {

--- a/services/hadoop-yarn-resourcemanager.json
+++ b/services/hadoop-yarn-resourcemanager.json
@@ -26,7 +26,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_yarn_resourcemanager]"
         }
       },
       "initialize": {

--- a/services/hbase-master.json
+++ b/services/hbase-master.json
@@ -30,7 +30,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase_master]"
         }
       },
       "initialize": {

--- a/services/hbase-regionserver.json
+++ b/services/hbase-regionserver.json
@@ -29,7 +29,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hbase_regionserver]"
         }
       },
       "start": {

--- a/services/hive-metastore.json
+++ b/services/hive-metastore.json
@@ -29,7 +29,7 @@
     "actions": {
       "configure": {
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive_metastore]"
         },
         "type": "chef-solo"
       },

--- a/services/hive-server2.json
+++ b/services/hive-server2.json
@@ -24,7 +24,7 @@
     "actions": {
       "configure": {
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hive_server2]"
         },
         "type": "chef-solo"
       },

--- a/services/spark-historyserver.json
+++ b/services/spark-historyserver.json
@@ -28,7 +28,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark_historyserver]"
         }
       },
       "initialize": {

--- a/services/spark-master.json
+++ b/services/spark-master.json
@@ -24,7 +24,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark_master]"
         }
       },
       "start": {

--- a/services/spark-worker.json
+++ b/services/spark-worker.json
@@ -24,7 +24,7 @@
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark]"
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::spark_worker]"
         }
       },
       "start": {


### PR DESCRIPTION
Changes in newer versions of the [hadoop cookbook](https://github.com/caskdata/hadoop_cookbook) have a templated init system which is affected by the configuration. This requires us to run the correct recipes. This is backwards-compatible with older cookbooks. Thanks to @dereklwood for pointing it out in #57 
