### PR TITLE
update to latest gce images

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -15,7 +15,7 @@
       "image": "11523085"
     },
     "google": {
-      "image": "centos-6-v20150226"
+      "image": "centos-6-v20160216"
     },
     "joyent": {
       "image": "5becfd74-a70d-11e4-93a6-470507be237c"

--- a/imagetypes/centos7.json
+++ b/imagetypes/centos7.json
@@ -6,7 +6,7 @@
       "image": "10322623"
     },
     "google": {
-      "image": "centos-7-v20150226"
+      "image": "centos-7-v20160216"
     },
     "joyent": {
       "image": "02dbab66-a70a-11e4-819b-b3dc41b361d6"

--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,7 +15,7 @@
       "image": "12247463"
     },
     "google": {
-      "image": "coreos-stable-522-6-0-v20150128"
+      "image": "coreos-stable-835-13-0-v20160218"
     },
     "rackspace": {
       "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"

--- a/imagetypes/debian7.json
+++ b/imagetypes/debian7.json
@@ -18,7 +18,7 @@
       "image": "10322059"
     },
     "google": {
-      "image": "debian-7-wheezy-v20150226"
+      "image": "debian-7-wheezy-v20160216"
     },
     "joyent": {
       "image": "5f41692e-a70d-11e4-8c2d-afc6735144dc"

--- a/imagetypes/ubuntu12.json
+++ b/imagetypes/ubuntu12.json
@@ -18,7 +18,7 @@
       "image": "10321756"
     },
     "google": {
-      "image": "ubuntu-1204-precise-v20150127",
+      "image": "ubuntu-1204-precise-v20160217a",
       "sshuser": "ubuntu"
     },
     "joyent": {

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -18,7 +18,7 @@
       "image": "11836690"
     },
     "google": {
-      "image": "ubuntu-1404-trusty-v20150128",
+      "image": "ubuntu-1404-trusty-v20160217a",
       "sshuser": "ubuntu"
     },
     "joyent": {


### PR DESCRIPTION
update to latest gce images

```
$ gcloud compute images list --project ubuntu-os-cloud
NAME                                PROJECT           ALIAS              DEPRECATED STATUS
ubuntu-1204-precise-v20160217a      ubuntu-os-cloud                                 READY
ubuntu-1404-trusty-v20160217a       ubuntu-os-cloud                                 READY
ubuntu-1504-vivid-v20160114a        ubuntu-os-cloud                                 READY
ubuntu-1510-wily-v20160217          ubuntu-os-cloud                                 READY
centos-6-v20160216                  centos-cloud      centos-6                      READY
centos-7-v20160216                  centos-cloud      centos-7                      READY
coreos-alpha-962-0-0-v20160218      coreos-cloud                                    READY
coreos-beta-899-7-0-v20160218       coreos-cloud                                    READY
coreos-stable-835-13-0-v20160218    coreos-cloud      coreos                        READY
backports-debian-7-wheezy-v20160216 debian-cloud      debian-7-backports            READY
debian-7-wheezy-v20160216           debian-cloud      debian-7                      READY
debian-8-jessie-v20160216           debian-cloud                                    READY
container-v1-2-v20160218            google-containers                               READY
container-vm-v20160217              google-containers container-vm                  READY
opensuse-13-2-v20160214             opensuse-cloud    opensuse-13                   READY
opensuse-leap-42-1-v20160214        opensuse-cloud                                  READY
rhel-6-v20160216                    rhel-cloud        rhel-6                        READY
rhel-7-v20160216                    rhel-cloud        rhel-7                        READY
sles-11-sp4-v20150714               suse-cloud        sles-11                       READY
sles-12-sp1-v20151215               suse-cloud                                      READY
```
