### PR TITLE
Increase AM resource percentage to 40% of cluster

### DIFF
--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -70,8 +70,10 @@
           "yarn.resourcemanager.resource-tracker.address": "%host.service.hadoop-yarn-resourcemanager%:8031",
           "yarn.resourcemanager.address": "%host.service.hadoop-yarn-resourcemanager%:8032",
           "yarn.resourcemanager.admin.address": "%host.service.hadoop-yarn-resourcemanager%:8033",
-          "yarn.scheduler.capacity.maximum-am-resource-percent": "0.4",
           "yarn.scheduler.minimum-allocation-mb": "256"
+        },
+        "capacity_scheduler": {
+          "yarn.scheduler.capacity.maximum-am-resource-percent": "0.4"
         }
       },
       "hbase": {


### PR DESCRIPTION
Increase AM resource percentage to 40% of cluster, when using capacity scheduler.

Follow up to PR: https://github.com/caskdata/coopr-templates/pull/54, as that was updating the wrong file.
