### PR TITLE
Update GCE images

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -1,6 +1,6 @@
 {
   "name": "centos6",
-  "description": "CentOS 6.5 64-bit",
+  "description": "CentOS 6 64-bit",
   "providermap": {
     "aws-us-east-1": {
       "image": "ami-eb6b0182"
@@ -15,7 +15,7 @@
       "image": "11523085"
     },
     "google": {
-      "image": "centos-6-v20160216"
+      "image": "centos-6-v20160329"
     },
     "joyent": {
       "image": "5becfd74-a70d-11e4-93a6-470507be237c"

--- a/imagetypes/centos7.json
+++ b/imagetypes/centos7.json
@@ -6,7 +6,7 @@
       "image": "10322623"
     },
     "google": {
-      "image": "centos-7-v20160216"
+      "image": "centos-7-v20160329"
     },
     "joyent": {
       "image": "02dbab66-a70a-11e4-819b-b3dc41b361d6"

--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,7 +15,7 @@
       "image": "12247463"
     },
     "google": {
-      "image": "coreos-stable-835-13-0-v20160218"
+      "image": "coreos-stable-899-15-0-v20160405"
     },
     "rackspace": {
       "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"

--- a/imagetypes/debian7.json
+++ b/imagetypes/debian7.json
@@ -18,7 +18,7 @@
       "image": "10322059"
     },
     "google": {
-      "image": "debian-7-wheezy-v20160216"
+      "image": "debian-7-wheezy-v20160329"
     },
     "joyent": {
       "image": "5f41692e-a70d-11e4-8c2d-afc6735144dc"

--- a/imagetypes/debian8.json
+++ b/imagetypes/debian8.json
@@ -1,0 +1,9 @@
+{
+  "name": "debian8",
+  "description": "Debian 8 (Jessie) 64-bit",
+  "providermap": {
+    "google": {
+      "image": "debian-8-jessie-v20160329"
+    }
+  }
+}

--- a/imagetypes/rhel6.json
+++ b/imagetypes/rhel6.json
@@ -1,0 +1,9 @@
+{
+  "name": "rhel6",
+  "description": "Redhat Enterprise Linux 6 64-bit",
+  "providermap": {
+    "google": {
+      "image": "rhel-6-v20160329"
+    }
+  }
+}

--- a/imagetypes/rhel7.json
+++ b/imagetypes/rhel7.json
@@ -1,0 +1,9 @@
+{
+  "name": "rhel7",
+  "description": "Redhat Enterprise Linux 7 64-bit",
+  "providermap": {
+    "google": {
+      "image": "rhel-7-v20160329"
+    }
+  }
+}

--- a/imagetypes/ubuntu12.json
+++ b/imagetypes/ubuntu12.json
@@ -18,7 +18,7 @@
       "image": "10321756"
     },
     "google": {
-      "image": "ubuntu-1204-precise-v20160217a",
+      "image": "ubuntu-1204-precise-v20160320",
       "sshuser": "ubuntu"
     },
     "joyent": {

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -18,7 +18,7 @@
       "image": "11836690"
     },
     "google": {
-      "image": "ubuntu-1404-trusty-v20160217a",
+      "image": "ubuntu-1404-trusty-v20160406",
       "sshuser": "ubuntu"
     },
     "joyent": {


### PR DESCRIPTION
This updates the GCE images to the latest, adds RHEL 6 and 7, and adds Debian 8.
