### PR TITLE
Support more images in base clustertemplate

### DIFF
--- a/clustertemplates/base.json
+++ b/clustertemplates/base.json
@@ -20,7 +20,14 @@
       "standard-2xlarge"
     ],
     "imagetypes": [
+      "centos5",
       "centos6",
+      "centos7",
+      "debian6",
+      "debian7",
+      "debian8",
+      "rhel6",
+      "rhel7",
       "ubuntu12"
     ],
     "services": [


### PR DESCRIPTION
Added all available versions except `ubuntu14` due to its repositories having an incompatible version of Chef, which has yet to be resolved.
