### PR TITLE
Ambari Cluster with Ambari Server and Agent(s)

### DIFF
--- a/clustertemplates/ambari.json
+++ b/clustertemplates/ambari.json
@@ -1,0 +1,55 @@
+{
+  "name": "ambari",
+  "description": "Ambari Server + Agent(s) on all nodes",
+  "defaults": {
+    "services": [
+      "base",
+      "ambari-server",
+      "ambari-agent"
+    ],
+    "provider": "rackspace",
+    "hardwaretype": "standard-xlarge",
+    "imagetype": "ubuntu12",
+    "config": {
+      "ambari": {
+        "server_url": "%host.service.ambari-server%",
+        "version": "2.2.1",
+        "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.2.1.1/ambari.repo",
+        "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.2.1.1"
+      }
+    }
+  },
+  "compatibility": {
+    "hardwaretypes": [
+      "standard-xlarge",
+      "standard-2xlarge"
+    ],
+    "imagetypes": [
+      "centos6",
+      "ubuntu12"
+    ],
+    "services": [
+      "base",
+      "ambari-server",
+      "ambari-agent",
+      "kerberos-client"
+    ]
+  },
+  "constraints": {
+    "services": {
+      "ambari-server": {
+        "quantities": {
+          "min": 1,
+          "max": 1
+        }
+      }
+    }
+  },
+  "administration": {
+    "leaseduration": {
+      "initial":0,
+      "max":0,
+      "step":0
+    }
+  }
+}

--- a/services/ambari-agent.json
+++ b/services/ambari-agent.json
@@ -1,0 +1,40 @@
+{
+  "name": "ambari-agent",
+  "description": "Ambari Agent",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": []
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "ambari-server" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::agent]"
+        }
+      },
+      "start": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::agent],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"ambari-agent\": \"start\" } } } }" 
+        }
+      },
+      "stop": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::agent],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"ambari-agent\": \"stop\" } } } }" 
+        }
+      }
+    }
+  }
+}

--- a/services/ambari-server.json
+++ b/services/ambari-server.json
@@ -1,0 +1,40 @@
+{
+  "name": "ambari-server",
+  "description": "Ambari Server",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": []
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": []
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::server]"
+        }
+      },
+      "start": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::server],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"ambari-server\": \"start\" } } } }" 
+        }
+      },
+      "stop": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[ambari::server],recipe[coopr_service_manager::default]",
+          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"ambari-server\": \"stop\" } } } }" 
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will install an Ambari Server on a single node and/or any number of Ambari Agents (including server node)...

Use cases:
- [x] Deploy an Ambari Server with a number of agents as a single cluster
- [x] Deploy an Ambari Server with no agents
- [x] Deploy only Agents pointed to a specific Ambari Server to grow an Ambari cluster
