### PR TITLE
Use correct config property (ambari.server_fqdn)

### DIFF
--- a/clustertemplates/ambari.json
+++ b/clustertemplates/ambari.json
@@ -12,7 +12,7 @@
     "imagetype": "ubuntu12",
     "config": {
       "ambari": {
-        "server_url": "%host.service.ambari-server%",
+        "server_fqdn": "%host.service.ambari-server%",
         "version": "2.2.1",
         "rhel_6_repo": "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.2.1.1/ambari.repo",
         "ubuntu_12_repo": "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.2.1.1"


### PR DESCRIPTION
The previous PR #69 used the incorrect attribute name for the Ambari server. The correct attribute is `ambari['server_fqdn']` as you can see at https://github.com/caskdata/coopr-provisioner/commit/249c95a5bcb413c5b25423ffb2b2d7f88664d0ba#diff-aeb5bf0a0488f561614f392b39da6429R6 so use that, instead.
