### PR TITLE
Fix link for cdap-standalone-docker template

### DIFF
--- a/clustertemplates/cdap-standalone-docker.json
+++ b/clustertemplates/cdap-standalone-docker.json
@@ -45,8 +45,8 @@
   },
   "links": [
     {
-      "label": "CDAP Console",
-      "url": "http://%ip.access_v4.service.cdap%:9999"
+      "label": "CDAP UI",
+      "url": "http://%ip.access_v4.service.cdap-standalone%:9999"
     }
   ]
 }


### PR DESCRIPTION
The link is pointing to the wrong service name and will never resolve.
