### PR TITLE
Create spark-client and have CDAP use it, if present

### DIFF
--- a/services/cdap.json
+++ b/services/cdap.json
@@ -13,7 +13,8 @@
       "uses": [
         "hadoop-client",
         "hbase-client",
-        "hive-client"
+        "hive-client",
+        "spark-client"
       ]
     },
     "provides": [],
@@ -30,6 +31,7 @@
       "uses": [
         "hive-metastore",
         "hive-server2",
+        "spark-historyserver",
         "cdap-security"
       ]
     }

--- a/services/spark-historyserver.json
+++ b/services/spark-historyserver.json
@@ -7,7 +7,9 @@
       "requires": [ "base" ],
       "uses": [ "kerberos-client" ]
     },
-    "provides": [],
+    "provides": [
+      "spark-client"
+    ],
     "runtime": {
       "requires": [],
       "uses": [


### PR DESCRIPTION
This will cause any `cdap` installation to happen after `spark-historyserver` which will ensure the client binaries are available.
