### PR TITLE
Publish all ports exposed by the official Cassandra image

### DIFF
--- a/services/cassandra-docker.json
+++ b/services/cassandra-docker.json
@@ -23,21 +23,21 @@
         "type": "docker",
         "fields": {
           "image_name": "cassandra",
-          "publish_ports": "7000"
+          "publish_ports": "7000,7001,7199,9042,9160"
         }
       },
       "start": {
         "type": "docker",
         "fields": {
           "image_name": "cassandra",
-          "publish_ports": "7000"
+          "publish_ports": "7000,7001,7199,9042,9160"
         }
       },
       "stop": {
         "type": "docker",
         "fields": {
           "image_name": "cassandra",
-          "publish_ports": "7000"
+          "publish_ports": "7000,7001,7199,9042,9160"
         }
       }
     }


### PR DESCRIPTION
Taken from `docker inspect` on a running container.
