### PR TITLE
Update to latest GCE CentOS images

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -15,7 +15,7 @@
       "image": "11523085"
     },
     "google": {
-      "image": "centos-6-v20160329"
+      "image": "centos-6-v20160526"
     },
     "joyent": {
       "image": "5becfd74-a70d-11e4-93a6-470507be237c"

--- a/imagetypes/centos7.json
+++ b/imagetypes/centos7.json
@@ -6,7 +6,7 @@
       "image": "10322623"
     },
     "google": {
-      "image": "centos-7-v20160329"
+      "image": "centos-7-v20160511"
     },
     "joyent": {
       "image": "02dbab66-a70a-11e4-819b-b3dc41b361d6"


### PR DESCRIPTION
This updates to the latest GCE CentOS images.

<img width="835" alt="screen shot 2016-05-26 at 6 58 20 pm" src="https://cloud.githubusercontent.com/assets/380021/15592717/0e34fe58-2374-11e6-9b39-84d650139b95.png">
