### PR TITLE
Support volumes for persistent storage

### DIFF
--- a/services/cassandra-docker.json
+++ b/services/cassandra-docker.json
@@ -22,22 +22,21 @@
       "install": {
         "type": "docker",
         "fields": {
-          "image_name": "cassandra",
-          "publish_ports": "7000,7001,7199,9042,9160"
+          "image_name": "cassandra"
         }
       },
       "start": {
         "type": "docker",
         "fields": {
           "image_name": "cassandra",
-          "publish_ports": "7000,7001,7199,9042,9160"
+          "publish_ports": "7000,7001,7199,9042,9160",
+          "volumes": "/data/cassandra:/var/lib/cassandra"
         }
       },
       "stop": {
         "type": "docker",
         "fields": {
-          "image_name": "cassandra",
-          "publish_ports": "7000,7001,7199,9042,9160"
+          "image_name": "cassandra"
         }
       }
     }

--- a/services/elasticsearch-docker.json
+++ b/services/elasticsearch-docker.json
@@ -30,6 +30,7 @@
         "fields": {
           "image_name": "elasticsearch",
           "publish_ports": "9200,9300",
+          "volumes": "/data/elasticsearch:/usr/share/elasticsearch/data",
           "command": "elasticsearch -Des.network.host=0.0.0.0"
         }
       },

--- a/services/mongodb-docker.json
+++ b/services/mongodb-docker.json
@@ -22,22 +22,21 @@
       "install": {
         "type": "docker",
         "fields": {
-          "image_name": "mongo",
-          "publish_ports": "27017"
+          "image_name": "mongo"
         }
       },
       "start": {
         "type": "docker",
         "fields": {
           "image_name": "mongo",
-          "publish_ports": "27017"
+          "publish_ports": "27017",
+          "volumes": "/data/mongodb:/data/db"
         }
       },
       "stop": {
         "type": "docker",
         "fields": {
-          "image_name": "mongo",
-          "publish_ports": "27017"
+          "image_name": "mongo"
         }
       }
     }


### PR DESCRIPTION
Remove `publish_ports` from non-install actions and add `volumes` pointing to official volumes for persistent data storage.
