### PR TITLE
Service definitions for MySQL and PostgreSQL via Docker

### DIFF
--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -32,7 +32,9 @@
       "coopr-standalone",
       "docker",
       "elasticsearch-docker",
-      "mongodb-docker"
+      "mongodb-docker",
+      "mysql-docker",
+      "postgresql-docker"
     ]
   },
   "constraints": {

--- a/services/mysql-docker.json
+++ b/services/mysql-docker.json
@@ -1,0 +1,45 @@
+{
+  "name": "mysql-docker",
+  "description": "MySQL running in a Docker container (mysql)",
+  "dependencies": {
+    "provides": [ "mysql", "database" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mysql"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mysql",
+          "publish_ports": "3306",
+          "environment_variables": "MYSQL_ROOT_PASSWORD=somedefaultpassword",
+          "volumes": "/data/mysql:/var/lib/mysql"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "mysql"
+        }
+      }
+    }
+  }
+}

--- a/services/mysql-server.json
+++ b/services/mysql-server.json
@@ -7,7 +7,7 @@
       "requires": [ "base" ],
       "uses": []
     },
-    "provides": [],
+    "provides": [ "mysql", "database" ],
     "runtime": {
       "requires": [],
       "uses": []

--- a/services/postgresql-docker.json
+++ b/services/postgresql-docker.json
@@ -1,0 +1,45 @@
+{
+  "name": "postgresql-docker",
+  "description": "PostgreSQL running in a Docker container (postgresql)",
+  "dependencies": {
+    "provides": [ "postgresql", "database" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "postgres"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "postgres",
+          "publish_ports": "5432",
+          "environment_variables": "POSTGRES_PASSWORD=somedefaultpassword",
+          "volumes": "/data/postgresql:/var/lib/postgresql/data"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "postgres"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These services use the official container images and require the new `environment_variables` and `volumes` support in the Coopr DockerAutomator introduced in caskdata/coopr-provisioner#122 and are added to `docker-all` clustertemplate.
