### PR TITLE
Update to latest GCE CoreOS image

### DIFF
--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,7 +15,7 @@
       "image": "12247463"
     },
     "google": {
-      "image": "coreos-stable-899-15-0-v20160405"
+      "image": "coreos-stable-1010-5-0-v20160527"
     },
     "rackspace": {
       "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"

--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,7 +15,7 @@
       "image": "12247463"
     },
     "google": {
-      "image": "coreos-stable-1010-5-0-v20160527"
+      "image": "coreos-stable-1068-8-0-v20160718"
     },
     "rackspace": {
       "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"


### PR DESCRIPTION
Update to the latest CoreOS image to prevent automatic reboots on update.
