### PR TITLE
Kerberos requires NTP

### DIFF
--- a/services/kerberos-client.json
+++ b/services/kerberos-client.json
@@ -18,7 +18,7 @@
       "install": {
         "type":"chef-solo",
         "fields": {
-          "run_list": "recipe[krb5::default]"
+          "run_list": "recipe[ntp::default],recipe[krb5::default]"
         }
       },
       "initialize": {

--- a/services/kerberos-master.json
+++ b/services/kerberos-master.json
@@ -18,7 +18,7 @@
       "install": {
         "type":"chef-solo",
         "fields": {
-          "run_list": "recipe[krb5::kadmin]"
+          "run_list": "recipe[ntp::default],recipe[krb5::kadmin]"
         }
       },
       "configure": {


### PR DESCRIPTION
This ensures that any cluster that adds Kerberos will also get NTP, since the `krb5` cookbook doesn't actually include the recipe for `ntp`
