### PR TITLE
Create hadoop-kerberos service to allow initialization

### DIFF
--- a/services/hadoop-hdfs-datanode.json
+++ b/services/hadoop-hdfs-datanode.json
@@ -14,6 +14,7 @@
       "requires": [ "hadoop-hdfs-namenode" ],
       "uses": [
         "hadoop-hdfs-secondarynamenode",
+        "hadoop-kerberos",
         "kerberos-master"
        ]
     }

--- a/services/hadoop-hdfs-namenode.json
+++ b/services/hadoop-hdfs-namenode.json
@@ -12,7 +12,10 @@
     ],
     "runtime": {
       "requires": [],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/hadoop-kerberos.json
+++ b/services/hadoop-kerberos.json
@@ -1,0 +1,26 @@
+{
+  "name": "hadoop-kerberos",
+  "description": "Creates Kerberos principals and keytabs",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [ "kerberos-master" ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "initialize": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::kerberos_init]"
+        }
+      }
+    }
+  }
+}

--- a/services/hadoop-mapreduce-historyserver.json
+++ b/services/hadoop-mapreduce-historyserver.json
@@ -14,6 +14,7 @@
     "runtime": {
       "requires": [],
       "uses": [
+        "hadoop-kerberos",
         "kerberos-master",
         "hadoop-yarn-resourcemanager"
       ]

--- a/services/hadoop-yarn-nodemanager.json
+++ b/services/hadoop-yarn-nodemanager.json
@@ -12,7 +12,10 @@
     ],
     "runtime": {
       "requires": [ "hadoop-yarn-resourcemanager" ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/hadoop-yarn-resourcemanager.json
+++ b/services/hadoop-yarn-resourcemanager.json
@@ -12,7 +12,10 @@
     ],
     "runtime": {
       "requires": [ "hadoop-hdfs-namenode", "hadoop-hdfs-datanode" ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/hbase-master.json
+++ b/services/hbase-master.json
@@ -16,7 +16,10 @@
         "hadoop-hdfs-datanode",
         "zookeeper-server"
       ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/hbase-regionserver.json
+++ b/services/hbase-regionserver.json
@@ -15,7 +15,10 @@
         "hbase-master",
         "zookeeper-server"
       ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/hive-server2.json
+++ b/services/hive-server2.json
@@ -17,7 +17,10 @@
         "zookeeper-server",
         "hive-metastore"
       ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/impala-catalog.json
+++ b/services/impala-catalog.json
@@ -16,6 +16,7 @@
         "zookeeper-server"
       ],
       "uses": [
+        "hadoop-kerberos",
         "kerberos-master",
         "impala-state-store"
       ]

--- a/services/impala-server.json
+++ b/services/impala-server.json
@@ -14,7 +14,10 @@
         "hadoop-hdfs-datanode",
         "impala-catalog"
       ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/impala-shell.json
+++ b/services/impala-shell.json
@@ -11,6 +11,7 @@
     "runtime": {
       "requires": [],
       "uses": [
+        "hadoop-kerberos",
         "kerberos-master",
         "impala-catalog",
         "impala-server",

--- a/services/impala-state-store.json
+++ b/services/impala-state-store.json
@@ -13,7 +13,10 @@
         "hadoop-hdfs-namenode",
         "hadoop-hdfs-datanode"
       ],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {

--- a/services/spark-historyserver.json
+++ b/services/spark-historyserver.json
@@ -13,6 +13,7 @@
     "runtime": {
       "requires": [],
       "uses": [
+        "hadoop-kerberos",
         "kerberos-master",
         "hadoop-hdfs-namenode",
         "hadoop-yarn-resourcemanager"

--- a/services/zookeeper-server.json
+++ b/services/zookeeper-server.json
@@ -10,7 +10,10 @@
     "provides": [],
     "runtime": {
       "requires": [],
-      "uses": [ "kerberos-master" ]
+      "uses": [
+        "hadoop-kerberos",
+        "kerberos-master"
+      ]
     }
   },
   "provisioner": {


### PR DESCRIPTION
Create a separate `hadoop-kerberos` service to run `hadoop_wrapper::kerberos_init` at INITIALIZE time. This causes the recipe to be run only after `kerberos-master` has been started on clustertemplates which include a local KDC.

This requires caskdata/hadoop_wrapper_cookbook#67
