### PR TITLE
latest gce images

### DIFF
--- a/imagetypes/centos6.json
+++ b/imagetypes/centos6.json
@@ -15,7 +15,7 @@
       "image": "11523085"
     },
     "google": {
-      "image": "centos-6-v20160921"
+      "image": "centos-6-v20161027"
     },
     "joyent": {
       "image": "5becfd74-a70d-11e4-93a6-470507be237c"

--- a/imagetypes/centos7.json
+++ b/imagetypes/centos7.json
@@ -6,7 +6,7 @@
       "image": "10322623"
     },
     "google": {
-      "image": "centos-7-v20160921"
+      "image": "centos-7-v20161027"
     },
     "joyent": {
       "image": "02dbab66-a70a-11e4-819b-b3dc41b361d6"

--- a/imagetypes/coreos-stable.json
+++ b/imagetypes/coreos-stable.json
@@ -15,7 +15,7 @@
       "image": "12247463"
     },
     "google": {
-      "image": "coreos-stable-1122-2-0-v20160906"
+      "image": "coreos-stable-1122-3-0-v20161021"
     },
     "rackspace": {
       "image": "a683c29b-8cb6-4ea1-b16e-d8d0c4a52823"

--- a/imagetypes/debian7.json
+++ b/imagetypes/debian7.json
@@ -18,7 +18,7 @@
       "image": "10322059"
     },
     "google": {
-      "image": "debian-7-wheezy-v20160329"
+      "image": "debian-7-wheezy-v20160531"
     },
     "joyent": {
       "image": "5f41692e-a70d-11e4-8c2d-afc6735144dc"

--- a/imagetypes/debian8.json
+++ b/imagetypes/debian8.json
@@ -3,7 +3,7 @@
   "description": "Debian 8 (Jessie) 64-bit",
   "providermap": {
     "google": {
-      "image": "debian-8-jessie-v20160923"
+      "image": "debian-8-jessie-v20161027"
     }
   }
 }

--- a/imagetypes/rhel6.json
+++ b/imagetypes/rhel6.json
@@ -3,7 +3,7 @@
   "description": "Redhat Enterprise Linux 6 64-bit",
   "providermap": {
     "google": {
-      "image": "rhel-6-v20160921"
+      "image": "rhel-6-v20161027"
     }
   }
 }

--- a/imagetypes/rhel7.json
+++ b/imagetypes/rhel7.json
@@ -3,7 +3,7 @@
   "description": "Redhat Enterprise Linux 7 64-bit",
   "providermap": {
     "google": {
-      "image": "rhel-7-v20160921"
+      "image": "rhel-7-v20161027"
     }
   }
 }

--- a/imagetypes/ubuntu12.json
+++ b/imagetypes/ubuntu12.json
@@ -18,7 +18,7 @@
       "image": "10321756"
     },
     "google": {
-      "image": "ubuntu-1204-precise-v20160919",
+      "image": "ubuntu-1204-precise-v20161020",
       "sshuser": "ubuntu"
     },
     "joyent": {

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -18,7 +18,7 @@
       "image": "11836690"
     },
     "google": {
-      "image": "ubuntu-1404-trusty-v20160919",
+      "image": "ubuntu-1404-trusty-v20161020",
       "sshuser": "ubuntu"
     },
     "joyent": {


### PR DESCRIPTION
update to latest gce images

```
$ gcloud compute images list | grep -e centos -e coreos -e debian -e rhel -e ubuntu
centos-6-v20161027                              centos-cloud       centos-6                              READY
centos-7-v20161027                              centos-cloud       centos-7                              READY
coreos-alpha-1214-0-0-v20161028                 coreos-cloud       coreos-alpha                          READY
coreos-beta-1185-2-0-v20161021                  coreos-cloud       coreos-beta                           READY
coreos-stable-1122-3-0-v20161021                coreos-cloud       coreos-stable                         READY
debian-8-jessie-v20161027                       debian-cloud       debian-8                              READY
rhel-6-v20161027                                rhel-cloud         rhel-6                                READY
rhel-7-v20161027                                rhel-cloud         rhel-7                                READY
ubuntu-1204-precise-v20161020                   ubuntu-os-cloud    ubuntu-1204-lts                       READY
ubuntu-1404-trusty-v20161020                    ubuntu-os-cloud    ubuntu-1404-lts                       READY
ubuntu-1604-xenial-v20161020                    ubuntu-os-cloud    ubuntu-1604-lts                       READY
ubuntu-1610-yakkety-v20161020                   ubuntu-os-cloud    ubuntu-1610                           READY
```
