### PR TITLE
Use EBS-backed Ubuntu AMIs

### DIFF
--- a/imagetypes/ubuntu12.json
+++ b/imagetypes/ubuntu12.json
@@ -3,15 +3,15 @@
   "description": "Ubuntu 12.04 LTS (Precise Pangolin) 64-bit",
   "providermap": {
     "aws-us-east-1": {
-      "image": "ami-d6cf93be",
+      "image": "ami-a488dbb3",
       "sshuser": "ubuntu"
     },
     "aws-us-west-1": {
-      "image": "ami-b1a044f5",
+      "image": "ami-46125926",
       "sshuser": "ubuntu"
     },
     "aws-us-west-2": {
-      "image": "ami-75755545",
+      "image": "ami-41cd6921",
       "sshuser": "ubuntu"
     },
     "digitalocean": {

--- a/imagetypes/ubuntu14.json
+++ b/imagetypes/ubuntu14.json
@@ -3,15 +3,15 @@
   "description": "Ubuntu 14.04 LTS (Trusty Tahr) 64-bit",
   "providermap": {
     "aws-us-east-1": {
-      "image": "ami-3e8ad556",
+      "image": "ami-a15e0db6",
       "sshuser": "ubuntu"
     },
     "aws-us-west-1": {
-      "image": "ami-17876353",
+      "image": "ami-6d064d0d",
       "sshuser": "ubuntu"
     },
     "aws-us-west-2": {
-      "image": "ami-ef3414df",
+      "image": "ami-38f25658",
       "sshuser": "ubuntu"
     },
     "digitalocean": {


### PR DESCRIPTION
This allows the user to specify the size of their disks, versus being stuck with instance-store sizes.