### PR TITLE
Rename CDAP/Coopr Standalone to match convention

### DIFF
--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -28,8 +28,8 @@
     "services": [
       "base",
       "cassandra-docker",
-      "cdap-standalone",
-      "coopr-standalone",
+      "cdap-standalone-docker",
+      "coopr-standalone-docker",
       "docker",
       "elasticsearch-docker",
       "mongodb-docker",

--- a/services/cdap-standalone-docker.json
+++ b/services/cdap-standalone-docker.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdap-standalone",
+  "name": "cdap-standalone-docker",
   "description": "CDAP SDK (Standalone) running in a Docker container (caskdata/cdap-standalone)",
   "dependencies": {
     "provides": [],

--- a/services/cdap-standalone-docker.json
+++ b/services/cdap-standalone-docker.json
@@ -1,6 +1,6 @@
 {
   "name": "cdap-standalone-docker",
-  "description": "CDAP SDK (Standalone) running in a Docker container (caskdata/cdap-standalone)",
+  "description": "CDAP Standalone running in a Docker container (caskdata/cdap-standalone)",
   "dependencies": {
     "provides": [],
     "conflicts": [

--- a/services/coopr-standalone-docker.json
+++ b/services/coopr-standalone-docker.json
@@ -1,5 +1,5 @@
 {
-  "name": "coopr-standalone",
+  "name": "coopr-standalone-docker",
   "description": "Coopr Standalone running in a Docker container (caskdata/coopr-standalone)",
   "dependencies": {
     "provides": [],


### PR DESCRIPTION
All of the other Docker-based services have `-docker` appended to them, so making our match, for consistency.