### PR TITLE
Increase the TMS container memory to 512m

### DIFF
--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -135,6 +135,7 @@
           "log.saver.run.memory.megs": "512",
           "master.service.memory.mb": "256",
           "master.service.num.cores": "1",
+          "messaging.container.memory.mb": "512",
           "metrics.memory.mb": "256",
           "metrics.num.cores": "2",
           "metrics.processor.memory.mb": "256",


### PR DESCRIPTION
- Observed through actually cluster that if set to
  256m, the container easily gets killed by YARN