### PR TITLE
Remove initialize from kerberos-client service

### DIFF
--- a/services/kerberos-client.json
+++ b/services/kerberos-client.json
@@ -21,12 +21,6 @@
           "run_list": "recipe[ntp::default],recipe[krb5::default]"
         }
       },
-      "initialize": {
-        "type":"chef-solo",
-        "fields": {
-          "run_list": "recipe[krb5_utils::default]"
-        }
-      },
       "configure": {
         "type":"chef-solo",
         "fields": {


### PR DESCRIPTION
This was previously a bit odd. We allowed for creating keytabs and principals via attributes in the cluster configuration. While this isn't necessarily bad, it can interfere with service-specific Kerberos configuration. If these attributes were set on a Hadoop cluster, they would override the settings in `hadoop_wrapper` cookbook and cause the cluster provisioning to fail. Services should take care of their own Kerberos needs.