### PR TITLE
Docker container service for etcd

### DIFF
--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -31,6 +31,7 @@
       "cdap-standalone-docker",
       "coopr-standalone-docker",
       "docker",
+      "etcd-docker",
       "elasticsearch-docker",
       "mongodb-docker",
       "mysql-docker",

--- a/services/etcd-docker.json
+++ b/services/etcd-docker.json
@@ -1,0 +1,42 @@
+{
+  "name": "etcd-docker",
+  "description": "Etcd running in a Docker container (etcd)",
+  "dependencies": {
+    "provides": [ "etcd" ],
+    "conflicts": [],
+    "install": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    },
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "docker"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type": "docker",
+        "fields": {
+          "image_name": "quay.io/coreos/etcd"
+        }
+      },
+      "start": {
+        "type": "docker",
+        "fields": {
+          "image_name": "quay.io/coreos/etcd"
+        }
+      },
+      "stop": {
+        "type": "docker",
+        "fields": {
+          "image_name": "quay.io/coreos/etcd"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the `etcd` daemon to Docker. This is the first step in coordinating containers.