### PR TITLE
update for latest mysql cookbook

### DIFF
--- a/clustertemplates/cdap-distributed.json
+++ b/clustertemplates/cdap-distributed.json
@@ -96,17 +96,18 @@
           "hive.support.concurrency": "true"
         }
       },
-      "mysql": {
-        "server_debian_password": "somedefaultpassword",
-        "server_root_password": "somedefaultpassword",
-        "server_repl_password": "somedefaultpassword",
-        "data_dir": "/data/mysql",
-        "server": {
-          "directories": {
-            "log_dir": "/data/mysql"
+      "coopr_mysql": {
+        "mysql_service": {
+          "hivedb": {
+            "bind_address": "%ip.bind_v4.service.mysql-server%",
+            "data_dir": "/data/mysql",
+            "initial_root_password": "somedefaultpassword",
+            "port": "3306"
           }
-        },
-        "bind_address": "%ip.bind_v4.service.mysql-server%"
+        }
+      },
+      "mysql": {
+        "server_root_password": "somedefaultpassword"
       },
       "cdap": {
         "cdap_site": {

--- a/clustertemplates/cdap-distributed.json
+++ b/clustertemplates/cdap-distributed.json
@@ -99,7 +99,7 @@
       "coopr_mysql": {
         "mysql_service": {
           "hivedb": {
-            "bind_address": "%ip.bind_v4.service.mysql-server%",
+            "bind_address": "0.0.0.0",
             "data_dir": "/data/mysql",
             "initial_root_password": "somedefaultpassword",
             "port": "3306"

--- a/clustertemplates/cdap-singlenode.json
+++ b/clustertemplates/cdap-singlenode.json
@@ -108,24 +108,25 @@
           "hive.server2.thrift.port": "10010"
         }
       },
-      "mysql": {
-        "tunable": {
-          "max_connections": "50",
-          "key_buffer_size": "16M",
-          "tmp_table_size": "16M",
-          "max_heap_table_size": "16M",
-          "bulk_insert_buffer_size": "16M"
-        },
-        "server_debian_password": "somedefaultpassword",
-        "server_root_password": "somedefaultpassword",
-        "server_repl_password": "somedefaultpassword",
-        "data_dir": "/data/mysql",
-        "server": {
-          "directories": {
-            "log_dir": "/data/mysql"
+      "coopr_mysql": {
+        "mysql_service": {
+          "hivedb": {
+            "bind_address": "127.0.0.1",
+            "data_dir": "/data/mysql",
+            "initial_root_password": "somedefaultpassword",
+            "mysqld_options": {
+              "max_connections": "50",
+              "key_buffer_size": "16M",
+              "tmp_table_size": "16M",
+              "max_heap_table_size": "16M",
+              "bulk_insert_buffer_size": "16M"
+            },
+            "port": "3306"
           }
-        },
-        "bind_address": "127.0.0.1"
+        }
+      },
+      "mysql": {
+        "server_root_password": "somedefaultpassword"
       },
       "cdap": {
         "cdap_site": {

--- a/clustertemplates/hadoop-distributed.json
+++ b/clustertemplates/hadoop-distributed.json
@@ -76,17 +76,18 @@
           "hive.zookeeper.quorum": "%join(map(host.service.zookeeper-server,'$'),',')%"
         }
       },
-      "mysql": {
-        "server_debian_password": "somedefaultpassword",
-        "server_root_password": "somedefaultpassword",
-        "server_repl_password": "somedefaultpassword",
-        "data_dir": "/data/mysql",
-        "server": {
-          "directories": {
-            "log_dir": "/data/mysql"
+      "coopr_mysql": {
+        "mysql_service": {
+          "hivedb": {
+            "bind_address": "%ip.bind_v4.service.mysql-server%",
+            "data_dir": "/data/mysql",
+            "initial_root_password": "somedefaultpassword",
+            "port": "3306"
           }
-        },
-        "bind_address": "%ip.bind_v4.service.mysql-server%"
+        }
+      },
+      "mysql": {
+        "server_root_password": "somedefaultpassword"
       },
       "zookeeper": {
         "zookeeper_env": {

--- a/clustertemplates/hadoop-distributed.json
+++ b/clustertemplates/hadoop-distributed.json
@@ -79,7 +79,7 @@
       "coopr_mysql": {
         "mysql_service": {
           "hivedb": {
-            "bind_address": "%ip.bind_v4.service.mysql-server%",
+            "bind_address": "0.0.0.0",
             "data_dir": "/data/mysql",
             "initial_root_password": "somedefaultpassword",
             "port": "3306"

--- a/clustertemplates/hadoop-singlenode.json
+++ b/clustertemplates/hadoop-singlenode.json
@@ -94,17 +94,18 @@
           "hive.server2.thrift.port": "10010"
         }
       },
-      "mysql": {
-        "server_debian_password": "somedefaultpassword",
-        "server_root_password": "somedefaultpassword",
-        "server_repl_password": "somedefaultpassword",
-        "data_dir": "/data/mysql",
-        "server": {
-          "directories": {
-            "log_dir": "/data/mysql"
+      "coopr_mysql": {
+        "mysql_service": {
+          "hivedb": {
+            "bind_address": "127.0.0.1",
+            "data_dir": "/data/mysql",
+            "initial_root_password": "somedefaultpassword",
+            "port": "3306"
           }
-        },
-        "bind_address": "127.0.0.1"
+        }
+      },
+      "mysql": {
+        "server_root_password": "somedefaultpassword"
       },
       "zookeeper": {
         "zookeeper_env": {

--- a/clustertemplates/lamp.json
+++ b/clustertemplates/lamp.json
@@ -38,17 +38,18 @@
           "ssl"
         ]
       },
-      "mysql": {
-        "server_debian_password": "somedefaultpassword",
-        "server_root_password": "somedefaultpassword",
-        "server_repl_password": "somedefaultpassword",
-        "data_dir": "/data/mysql",
-        "server": {
-          "directories": {
-            "log_dir": "/data/mysql"
+      "coopr_mysql": {
+        "mysql_service": {
+          "lamp": {
+            "bind_address": "%ip.bind_v4.service.mysql-server%",
+            "data_dir": "/data/mysql",
+            "initial_root_password": "somedefaultpassword",
+            "port": "3306"
           }
-        },
-        "bind_address": "%ip.bind_v4.service.mysql-server%"
+        }
+      },
+      "mysql": {
+        "server_root_password": "somedefaultpassword"
       },
       "php": {
         "directives": {

--- a/services/mysql-server.json
+++ b/services/mysql-server.json
@@ -18,27 +18,27 @@
       "install": {
         "type":"chef-solo",
         "fields": {
-          "run_list": "recipe[mysql::server]"
+          "run_list": "recipe[coopr_mysql]"
         }
       },
       "configure": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[mysql::server]"
+          "run_list": "recipe[coopr_mysql]"
         }
       },
       "start": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[mysql::server],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"mysql\": \"start\" } } } }" 
+          "run_list": "recipe[coopr_mysql]",
+          "json_attributes": "{\"coopr_mysql\": { \"action\": \"start\" } }"
         }
       },
       "stop": {
         "type": "chef-solo",
         "fields": {
-          "run_list": "recipe[mysql::server],recipe[coopr_service_manager::default]",
-          "json_attributes": "{\"coopr\": { \"node\": { \"services\": { \"mysql\": \"stop\" } } } }" 
+          "run_list": "recipe[coopr_mysql]",
+          "json_attributes": "{\"coopr_mysql\": { \"action\": \"stop\" } }"
         }
       }
     }


### PR DESCRIPTION


   - ``mysql-server`` service updated to use new ``coopr_mysql`` cookbook
   - updated public templates to work with this service/cookbook.  Each template has the following changes

      - reorganized existing attributes under coopr_mysql where the coopr_mysql cookbook expects them
      - gave each mysql_service a service name, as required. ie, "hivedb", resulting in /etc/init.d/mysql-hivedb
      - i didn't bother specifying the error_log directory... i think the standard /var/log is fine
      - the mysql password attribute is preserved for use-cases where it is needed as a client... ie hadoop_wrapper connecting to the remote db to setup users/perms via the database lwrps.

