### PR TITLE
Add empty aws_root_ebs_size and aws_root_ebs_delete_on_term

### DIFF
--- a/providers/aws-us-east-1.json
+++ b/providers/aws-us-east-1.json
@@ -10,6 +10,8 @@
     "aws_region": "us-east-1",
     "aws_ebs_size": "",
     "aws_ebs_delete_on_term": "",
+    "aws_root_ebs_size": "",
+    "aws_root_ebs_delete_on_term": "",
     "security_groups": "",
     "security_group_ids": "",
     "subnet_id": "",

--- a/providers/aws-us-west-1.json
+++ b/providers/aws-us-west-1.json
@@ -10,6 +10,8 @@
     "aws_region": "us-west-1",
     "aws_ebs_size": "",
     "aws_ebs_delete_on_term": "",
+    "aws_root_ebs_size": "",
+    "aws_root_ebs_delete_on_term": "",
     "security_groups": "",
     "security_group_ids": "",
     "subnet_id": "",

--- a/providers/aws-us-west-2.json
+++ b/providers/aws-us-west-2.json
@@ -10,6 +10,8 @@
     "aws_region": "us-west-2",
     "aws_ebs_size": "",
     "aws_ebs_delete_on_term": "",
+    "aws_root_ebs_size": "",
+    "aws_root_ebs_delete_on_term": "",
     "security_groups": "",
     "security_group_ids": "",
     "subnet_id": "",


### PR DESCRIPTION
Set these to empty strings so they display correctly in the UI
after caskdata/coopr-provisioner#232 is merged. The old entries
are left to keep any existing templates functional.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>