### PR TITLE
replace cdap-standalone-docker service with cdap-sandbox-docker service

### DIFF
--- a/clustertemplates/cdap-sandbox-docker.json
+++ b/clustertemplates/cdap-sandbox-docker.json
@@ -1,9 +1,9 @@
 {
-  "name": "cdap-standalone-docker",
-  "description": "CDAP SDK (Standalone) in a Docker container",
+  "name": "cdap-sandbox-docker",
+  "description": "CDAP Sandbox in a Docker container",
   "defaults": {
     "services": [
-      "cdap-standalone"
+      "cdap-sandbox-docker"
     ],
     "provider": "rackspace",
     "hardwaretype": "standard-medium",
@@ -22,7 +22,7 @@
       "coreos-stable"
     ],
     "services": [
-      "cdap-standalone"
+      "cdap-sandbox-docker"
     ]
   },
   "constraints": {
@@ -46,7 +46,7 @@
   "links": [
     {
       "label": "CDAP UI",
-      "url": "http://%ip.access_v4.service.cdap-standalone%:9999"
+      "url": "http://%ip.access_v4.service.cdap-sandbox-docker%:11011"
     }
   ]
 }

--- a/clustertemplates/docker-all.json
+++ b/clustertemplates/docker-all.json
@@ -28,7 +28,7 @@
     "services": [
       "base",
       "cassandra-docker",
-      "cdap-standalone-docker",
+      "cdap-sandbox-docker",
       "coopr-standalone-docker",
       "docker",
       "elasticsearch-docker",

--- a/services/cdap-sandbox-docker.json
+++ b/services/cdap-sandbox-docker.json
@@ -1,6 +1,6 @@
 {
-  "name": "cdap-standalone-docker",
-  "description": "CDAP Standalone running in a Docker container (caskdata/cdap-standalone)",
+  "name": "cdap-sandbox-docker",
+  "description": "CDAP Sandbox running in a Docker container (caskdata/cdap-sandbox)",
   "dependencies": {
     "provides": [],
     "conflicts": [
@@ -24,22 +24,22 @@
       "install": {
         "type": "docker",
         "fields": {
-          "image_name": "caskdata/cdap-standalone",
-          "publish_ports": "9999,10000"
+          "image_name": "caskdata/cdap-sandbox",
+          "publish_ports": "11011,11015"
         }
       },
       "start": {
         "type": "docker",
         "fields": {
-          "image_name": "caskdata/cdap-standalone",
-          "publish_ports": "9999,10000"
+          "image_name": "caskdata/cdap-sandbox",
+          "publish_ports": "11011,11015"
         }
       },
       "stop": {
         "type": "docker",
         "fields": {
-          "image_name": "caskdata/cdap-standalone",
-          "publish_ports": "9999,10000"
+          "image_name": "caskdata/cdap-sandbox",
+          "publish_ports": "11011,11015"
         }
       }
     }

--- a/services/cdap-sandbox-docker.json
+++ b/services/cdap-sandbox-docker.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "provides": [],
     "conflicts": [
-      "cdap"
+      "cdap",
+      "cdap-standalone-docker"
     ],
     "install": {
       "requires": [],

--- a/services/cdap.json
+++ b/services/cdap.json
@@ -2,7 +2,7 @@
   "name": "cdap",
   "description": "Cask DAP (CDAP)",
   "dependencies": {
-    "conflicts": ["cdap-standalone"],
+    "conflicts": ["cdap-sandbox-docker"],
     "install": {
       "requires": [
         "base",


### PR DESCRIPTION
`cdap-standalone` was renamed to `cask-sandbox` starting with 4.2, including the docker image.

This replaces the service, corrects the ports, and updates/fixes the service references in the clustertemplates.