### PR TITLE
Use coopr_docker cookbook

### DIFF
--- a/services/docker.json
+++ b/services/docker.json
@@ -18,13 +18,13 @@
     "actions": {
       "install": {
         "fields": {
-          "run_list": "recipe[docker]"
+          "run_list": "recipe[coopr_docker]"
         },
         "type": "chef-solo"
       },
       "configure": {
         "fields": {
-          "run_list": "recipe[docker]"
+          "run_list": "recipe[coopr_docker]"
         },
         "type": "chef-solo"
       }


### PR DESCRIPTION
Switch to using the coopr_docker cookbook. This requires that
caskdata/coopr-provisioner#247 and caskdata/coopr-provisioner#248
are merged.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>