### PR TITLE
recommended nomenclature updates

### DIFF
--- a/clustertemplates/dcos-single-master.json
+++ b/clustertemplates/dcos-single-master.json
@@ -4,7 +4,7 @@
   "defaults": {
     "services": [
       "dcos-master",
-      "dcos-slave"
+      "dcos-private-agent"
     ],
     "provider": "google",
     "hardwaretype": "standard-xlarge",
@@ -30,8 +30,8 @@
     ],
     "services": [
       "dcos-master",
-      "dcos-slave",
-      "dcos-slave-public"
+      "dcos-private-agent",
+      "dcos-public-agent"
     ]
   },
   "administration": {
@@ -50,8 +50,8 @@
       "cantcoexist": [
         [
           "dcos-master",
-          "dcos-slave",
-          "dcos-slave-public"
+          "dcos-private-agent",
+          "dcos-public-agent"
         ]
       ]
     },
@@ -62,12 +62,12 @@
           "max": 1
         }
       },
-      "dcos-slave": {
+      "dcos-private-agent": {
         "quantities": {
           "min": 1
         }
       },
-      "dcos-slave-public": {
+      "dcos-public-agent": {
         "quantities": {
           "min": 0,
           "max": 1

--- a/services/dcos-private-agent.json
+++ b/services/dcos-private-agent.json
@@ -1,6 +1,6 @@
 {
-  "name": "dcos-slave",
-  "description": "DC/OS Slave service",
+  "name": "dcos-private-agent",
+  "description": "DC/OS Private Agent",
   "dependencies": {
     "conflicts": [],
     "install": {

--- a/services/dcos-public-agent.json
+++ b/services/dcos-public-agent.json
@@ -1,6 +1,6 @@
 {
-  "name": "dcos-slave-public",
-  "description": "DC/OS Public Slave service",
+  "name": "dcos-public-agent",
+  "description": "DC/OS Public Agent service",
   "dependencies": {
     "conflicts": [],
     "install": {


### PR DESCRIPTION
Using updated nomenclature, keeping consistent with what DC/OS calls their nodes now: https://docs.d2iq.com/mesosphere/dcos/2.0/overview/architecture/node-types/.

Underlying API not changed, per https://docs.d2iq.com/mesosphere/dcos/2.2/installing/production/deploying-dcos/installation/#install-dcos